### PR TITLE
fix: prevent crashing on SSR

### DIFF
--- a/lib/modules/bridge.js
+++ b/lib/modules/bridge.js
@@ -2,18 +2,20 @@ let loaded = false;
 const callbacks = [];
 
 export const loadBridge = (src) => {
-  // Way to make sure all event handlers are called after loading
-  window.storyblokRegisterEvent = (cb) => {
-    if (window.location === window.parent.location) {
-      console.warn("You are not in Draft Mode or in the Visual Editor.");
-      return;
-    }
-
-    if (!loaded) callbacks.push(cb);
-    else cb();
-  };
-
   return new Promise((resolve, reject) => {
+    if (typeof window === "undefined") return;
+
+    // Way to make sure all event handlers are called after loading
+    window.storyblokRegisterEvent = (cb) => {
+      if (window.location === window.parent.location) {
+        console.warn("You are not in Draft Mode or in the Visual Editor.");
+        return;
+      }
+
+      if (!loaded) callbacks.push(cb);
+      else cb();
+    };
+
     if (document.getElementById("storyblok-javascript-bridge")) return;
 
     const script = document.createElement("script");

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
       "prettier"
     ],
     "env": {
-      "browser": true
+      "browser": true,
+      "es6": true
     },
     "ignorePatterns": "dist/",
     "parserOptions": {


### PR DESCRIPTION
When using the lib in SSR (like in Next.js or Nuxt.js) it was crashing due to `loadBridge` was directly accessing window without any check. That's fixed