### PR TITLE
fix: sbBlokKeyDataTypes missing for boolean type #73

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,7 +17,7 @@ export interface SbInitResult {
 }
 
 export type SbPluginFactory = (options: SbSDKOptions) => any;
-export type SbBlokKeyDataTypes = string | number | object;
+export type SbBlokKeyDataTypes = string | number | object | boolean;
 
 export interface SbBlokData extends StoryblokComponent<string> {
   [index: string]: SbBlokKeyDataTypes;


### PR DESCRIPTION
Related issue: #73 