### PR TITLE
Strict types in useStoryblokBridge hook

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,9 +9,9 @@ import {
 
 const bridgeLatest = "https://app.storyblok.com/f/storyblok-v2-latest.js";
 
-export const useStoryblokBridge = (
+export const useStoryblokBridge = <T = void>(
   id: Number,
-  cb: (newStory: StoryData) => void,
+  cb: (newStory: StoryData<T>) => void,
   options: StoryblokBridgeConfigV2 = {}
 ) => {
   if (typeof window === "undefined") {


### PR DESCRIPTION
In a strongly typed TS application the type of `newStory` is not assignable to story since the return type of story doesn't match. This PR is to allow a generic type to be passed to the hook.

Usage:
`useStoryblokBridge<BlogStoryblok>(story.id, newStory => (story = newStory))`