### PR TITLE
fix:  correct checks for useStoryblokBridge

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -44,9 +44,10 @@ export const useStoryblokBridge = <
   window.storyblokRegisterEvent(() => {
     const sbBridge: StoryblokBridgeV2 = new window.StoryblokBridge(options);
     sbBridge.on(["input", "published", "change"], (event) => {
-      if (event.story.id === id) {
-        if (event.action === "input") cb(event.story);
-        else window.location.reload();
+      if (event.action === "input" && event.story.id === id) {
+        cb(event.story);
+      } else if (event.action === "change" || event.action === "published") {
+        window.location.reload();
       }
     });
   });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -48,7 +48,7 @@ export const useStoryblokBridge = <
         cb(event.story);
       } else if (
         (event.action === "change" || event.action === "published") &&
-        event.storyId === id
+        (event.storyId as any) === id // @todo: "as any" is a temporary fix till https://github.com/storyblok/storyblok-js-client/pull/280 is merged
       ) {
         window.location.reload();
       }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -46,7 +46,10 @@ export const useStoryblokBridge = <
     sbBridge.on(["input", "published", "change"], (event) => {
       if (event.action === "input" && event.story.id === id) {
         cb(event.story);
-      } else if (event.action === "change" || event.action === "published") {
+      } else if (
+        (event.action === "change" || event.action === "published") &&
+        event.storyId === id
+      ) {
         window.location.reload();
       }
     });

--- a/playground/main.ts
+++ b/playground/main.ts
@@ -2,6 +2,8 @@ import {
   storyblokInit,
   loadStoryblokBridge,
   renderRichText,
+  useStoryblokBridge,
+  apiPlugin,
 } from "@storyblok/js";
 import richTextFixture from "../lib/fixtures/richTextObject.json";
 
@@ -44,21 +46,31 @@ declare global {
   }
 }
 
-window.initWithBridge = () => {
-  storyblokInit({
-    accessToken: "wANpEQEsMYGOwLxwXQ76Ggtt",
+window.initWithBridge = async () => {
+  const { storyblokApi } = storyblokInit({
+    accessToken: "OurklwV5XsDJTIE1NJaD2wtt",
+    use: [apiPlugin],
+  });
+
+  const { data } = await storyblokApi?.get("cdn/stories/js", {
+    version: "draft",
+  });
+
+  useStoryblokBridge(data.story.id, (newStory) => {
+    console.log("-- PLAYGROUND --");
+    console.log(newStory);
   });
 };
 
 window.initWithoutBridge = () => {
   storyblokInit({
-    accessToken: "wANpEQEsMYGOwLxwXQ76Ggtt",
+    accessToken: "OurklwV5XsDJTIE1NJaD2wtt",
     bridge: false,
   });
 };
 window.initCustomRichText = () => {
   storyblokInit({
-    accessToken: "wANpEQEsMYGOwLxwXQ76Ggtt",
+    accessToken: "OurklwV5XsDJTIE1NJaD2wtt",
     richText: {
       schema: customSchema,
       resolver: customComponentResolver,

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -3,4 +3,7 @@ import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [],
+  server: {
+    https: true,
+  },
 });


### PR DESCRIPTION
Fixes the crash mentioned in https://github.com/storyblok/storyblok-react/issues/229#issuecomment-1243709670 due to having the `change` and `published` events a different data structure, as shown in the image below.

@fgiuliani I've also added an extra thing to the `initWithBridge` function on the playground, just to make easier testing/reproduction.
![Screenshot 2022-09-13 at 13 42 54](https://user-images.githubusercontent.com/5701162/189895248-6d7064a4-6052-4e69-9af8-ec8b01660a6e.png)

