### PR TITLE
Fixing loading storyblok brdige even if it is not needed

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -73,9 +73,10 @@ export const storyblokInit = (pluginOptions: SbSDKOptions = {}) => {
   use.forEach((pluginFactory: Function) => {
     result = { ...result, ...pluginFactory(options) };
   });
-
+  
+  const inEditor = window && window.location && window.location.search && window.location.search.includes('_storyblok_tk');
   // Load bridge
-  if (bridge !== false) {
+  if (bridge !== false && inEditor) {
     loadBridge(bridgeLatest);
   }
 


### PR DESCRIPTION
The storyblok bridge is loaded even it is not needed

The current implementation loads "storyblok-v2-latest.js" everytime.

But we only need it in the editor, this flag checks if we are in the editor.

I don't know if this is the right way to check or if those values change which is why I am publishing this as a draft