### PR TITLE
fix: only load bridge if correct search parameters and in editor

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -75,8 +75,15 @@ export const storyblokInit = (pluginOptions: SbSDKOptions = {}) => {
   });
 
   // Load bridge
-  if (bridge !== false) {
-    loadBridge(bridgeLatest);
+  const searchParams = new URLSearchParams(window.location.search);
+  if (bridge !== false && searchParams.has("_storyblok")) {
+    if (window.location !== window.parent.location) {
+      loadBridge(bridgeLatest);
+    } else {
+      console.warn(
+        "You are not in the Visual Editor, but you are loading a preview url. Did not load bridge."
+      );
+    }
   }
 
   // Rich Text resolver

--- a/playground/index.html
+++ b/playground/index.html
@@ -7,6 +7,9 @@
   </head>
   <body>
     <div>Hello</div>
+    <button class="with-parameters" onclick="window.location.href = '/js?_storyblok=110300312&_storyblok_c=page&_storyblok_version=&_storyblok_lang=default&_storyblok_release=0&_storyblok_rl=1675712669970&_storyblok_tk[space_id]=151486&_storyblok_tk[timestamp]=1675712641&_storyblok_tk[token]=d0b811d1ac1bdfa94d00790825d48cd9570baea3'">
+      go to url with search parameters
+    </button>
     <button class="with-bridge" onclick="initWithBridge()">
       storyblokInit With Bridge
     </button>


### PR DESCRIPTION
* Checks against window.parent.location to check if we are in editor - [Based on how the bridge handles it](https://github.com/storyblok/storyblok-js/blob/main/lib/modules/bridge.ts#L10)
* Checks against _storyblok to see if we have a draft link - #214, [based on proposed fix in nuxt](https://github.com/storyblok/storyblok-nuxt/pull/227)