### PR TITLE
feat: add isRichTextEmpty util

### DIFF
--- a/lib/fixtures/emptyRichTextObject.json
+++ b/lib/fixtures/emptyRichTextObject.json
@@ -1,0 +1,8 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "paragraph"
+    }
+  ]
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -107,8 +107,12 @@ const setComponentResolver = (resolver, resolveFn) => {
   });
 };
 
+export const isRichTextEmpty = (data?: ISbRichtext) => {
+return !data || (data?.content?.[0].type !== "blok" && !data?.content?.[0].content);
+}
+
 export const renderRichText = (
-  data: ISbRichtext,
+  data?: ISbRichtext,
   options?: SbRichTextOptions,
   resolverInstance?: RichtextResolver
 ): string => {
@@ -120,12 +124,7 @@ export const renderRichText = (
     return;
   }
 
-  if ((data as any) === "") {
-    return "";
-  } else if (!data) {
-    console.warn(`${data} is not a valid Richtext object. This might be because the value of the richtext field is empty.
-    
-  For more info about the richtext object check https://github.com/storyblok/storyblok-js#rendering-rich-text`);
+  if (isRichTextEmpty(data)) {
     return "";
   }
 

--- a/lib/tests/__snapshots__/index.test.js.snap
+++ b/lib/tests/__snapshots__/index.test.js.snap
@@ -1,3 +1,5 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`@storyblok/js > Rich Text Resolver > should return the rendered HTML when passing a RichText object 1`] = `"<p>Hola<b>in bold</b></p>"`;
+
+exports[`@storyblok/js > Rich Text Resolver > should return the rendered HTML when passing a valid RichText object 1`] = `"<p>Hola<b>in bold</b></p>"`;

--- a/lib/tests/index.test.js
+++ b/lib/tests/index.test.js
@@ -73,6 +73,10 @@ describe("@storyblok/js", () => {
       storyblokInit({ accessToken: "wANpEQEsMYGOwLxwXQ76Ggtt", bridge: false });
       expect(isRichTextEmpty(emptyRichTextFixture)).toBe(true);
     })
+    it("should return false when passing a valid RichText object", () => {
+      storyblokInit({ accessToken: "wANpEQEsMYGOwLxwXQ76Ggtt", bridge: false });
+      expect(isRichTextEmpty(richTextFixture)).toBe(false);
+    })
     it("should return true when passing a falsy value", () => {
       storyblokInit({ accessToken: "wANpEQEsMYGOwLxwXQ76Ggtt", bridge: false });
       expect(isRichTextEmpty("")).toBe(true);

--- a/lib/tests/index.test.js
+++ b/lib/tests/index.test.js
@@ -3,10 +3,12 @@ import {
   apiPlugin,
   storyblokEditable,
   renderRichText,
+  isRichTextEmpty,
 } from "@storyblok/js";
 import { describe, it, expect, vi, afterEach } from "vitest";
 
 import richTextFixture from "../fixtures/richTextObject.json";
+import emptyRichTextFixture from "../fixtures/emptyRichTextObject.json";
 
 describe("@storyblok/js", () => {
   afterEach(() => {
@@ -66,23 +68,21 @@ describe("@storyblok/js", () => {
     });
   });
 
+  describe("isRichTextEmpty", () => {
+    it("should return true when passing an empty or invalid RichText object", () => {
+      storyblokInit({ accessToken: "wANpEQEsMYGOwLxwXQ76Ggtt", bridge: false });
+      expect(isRichTextEmpty(emptyRichTextFixture)).toBe(true);
+    })
+    it("should return true when passing a falsy value", () => {
+      storyblokInit({ accessToken: "wANpEQEsMYGOwLxwXQ76Ggtt", bridge: false });
+      expect(isRichTextEmpty("")).toBe(true);
+    })
+  })
+
   describe("Rich Text Resolver", () => {
-    it("should return the rendered HTML when passing a RichText object", () => {
+    it("should return the rendered HTML when passing a valid RichText object", () => {
       storyblokInit({ accessToken: "wANpEQEsMYGOwLxwXQ76Ggtt", bridge: false });
       expect(renderRichText(richTextFixture)).toMatchSnapshot();
-    });
-    it("should return an empty string and warn in console when it's a falsy value", () => {
-      const spy = vi.spyOn(console, "warn");
-      storyblokInit({ accessToken: "wANpEQEsMYGOwLxwXQ76Ggtt", bridge: false });
-      expect(renderRichText(null)).toBe("");
-      expect(spy)
-        .toBeCalledWith(`null is not a valid Richtext object. This might be because the value of the richtext field is empty.
-    
-  For more info about the richtext object check https://github.com/storyblok/storyblok-js#rendering-rich-text`);
-    });
-    it("should return an empty string when the value it's an empty string", () => {
-      storyblokInit({ accessToken: "wANpEQEsMYGOwLxwXQ76Ggtt", bridge: false });
-      expect(renderRichText(null)).toBe("");
     });
   });
 });


### PR DESCRIPTION
This PR adds an `isRichtextEmpty` utility function that can be used independently to check whether a `richtext` field is empty, and updates the behavior of the render function when passing a falsy value.

Currently, an empty `richtext` field returns the following JSON:

```
"richtext":
     {
       "type": "doc",
        "content":
           [
               {
                  "type": "paragraph"
               }
            ]
     },

```

This means that:

1. Accessing the `richtext` data simply through `blok.richtext` will always return true, even if the field is empty. Conditional logic based on accessing `richtext` like this won't work.
2. The check in the current implementation in the `renderRichText` function, outlined below, will pass for all `richtext` data given to it, since a `richtext` field will always return a structure, even if the field is empty. In which case, instead of users receiving the console warning about empty or undefined `richtext` fields, a set of empty `<p></p>` tags gets rendered.

```
 if ((data as any) === "") {
    return "";
  } else if (!data) {
    console.warn(`${data} is not a valid Richtext object. This might be because the value of the richtext field is empty.
    
  For more info about the richtext object check https://github.com/storyblok/storyblok-js#rendering-rich-text`);
    return "";
  }

```

My proposed approach to handling this scenario is to

- Add a utility function for truly checking whether the `richtext` field is empty that can be used independently
    - This enables users to create conditional logic based on the state of the `richtext` field outside of the renderer
- Replacing the current check inside the renderer with the new method
- Remove console warning since it is redundant - empty `richtext` fields will render nothing instead of empty `<p></p>` tags, there's nothing to warn users about. If they want to explicitly be informed of the state of the field, they can use the newly added method to check whether the value is valid or not.

I am not too sure whether the last step is the best approach. Are there cases when users would **want** to be warned that the `richtext` field currently being handled is empty? Are there use cases where a `richtext` field can be an empty string, and is there a reason the current implementation of the `data` check does not return a warning if it's an empty string, but returns a warning for other falsy values? Is there something to distinguish here? 

Personally, I find the experience of not having to worry about the state of the `richtext` at all and letting the renderer resolve it very appealing, and I wouldn't want to be forced to use `isRichTextEmpty` in conjunction with the renderer every time I am parsing any `richtext` in order to avoid that warning. But there may have been other perspectives and use cases that I've missed, so I'm more than happy to reconsider and change any of the approaches listed above. 😄

## Other information

I have made the `data` parameter for the `isRichTextEmpty` method optional so that TS doesn't yell at you if you're using the [storyblok-generate-ts](https://www.npmjs.com/package/storyblok-generate-ts) package to generate types for you, a lot of which end up having conditional fields if the fields aren't set as mandatory in the CMS. If this is not desired behavior, I'm happy to update :)

I have also added and updated tests to be aligned with the updated logic - I added a test for `isRichTextEmpty` to ensure it handles empty fields correctly, and that is also handles falsy values. Since the render method uses `isRichTextEmpty` internally, I have updated the test for it to only check that it returns the correct HTML when passed valid `richtext`, since any invalid cases should then be handled by `isRichTextEmpty`. 