### PR TITLE
fix: protect against invalid editable data

### DIFF
--- a/lib/modules/editable.ts
+++ b/lib/modules/editable.ts
@@ -5,16 +5,20 @@ export default (blok: SbBlokData) => {
     return {};
   }
 
-  const options = JSON.parse(
-    blok._editable.replace(/^<!--#storyblok#/, "").replace(/-->$/, "")
-  );
+  try {
+    const options = JSON.parse(
+      blok._editable.replace(/^<!--#storyblok#/, "").replace(/-->$/, "")
+    );
 
-  if (options) {
-    return {
-      "data-blok-c": JSON.stringify(options),
-      "data-blok-uid": options.id + "-" + options.uid,
-    };
+    if (options) {
+      return {
+        "data-blok-c": JSON.stringify(options),
+        "data-blok-uid": options.id + "-" + options.uid,
+      };
+    }
+
+    return {};    
+  } catch {
+    return {};
   }
-
-  return {};
 };


### PR DESCRIPTION
`_editable` could contain an invalid value, such as `null` when using GraphQL. This can cause a exception.

This fix prevents issues when the value of _editable is not what is expected.

This issue was also mentioned here: https://github.com/storyblok/storyblok-editable/issues/4

![Screenshot 2023-10-31 at 15 56 45](https://github.com/storyblok/storyblok-js/assets/4291318/b6faa29d-559a-4b17-8d06-ae0f878c790a)
