### PR TITLE
feat: add new `@storyblok/richtext` exports with retro-compatibilty with legacy `RichTextResolver`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,25 +14,6 @@ import { RichtextResolver } from "storyblok-js-client";
 
 import { type SbRichTextOptions as stdSbRichTextOptions} from "@storyblok/richtext";
 
-/**
- * This is a temporaly class to avoid type collision with the legacy richtext resolver.
- * It will become ~~`newSbRichTextOptions`~~ -> `SbRichTextOptions` on v4.x
- */
-export type newSbRichTextOptions = stdSbRichTextOptions;
-
-// New Richtext Resolver
-export {
-  BlockTypes,
-  MarkTypes,
-  richTextResolver,
-  TextTypes,
-  type SbRichTextDocumentNode,
-  type SbRichTextNodeTypes,
-  type SbRichTextNode,
-  type SbRichTextResolvers,
-  type SbRichTextNodeResolver,
-  type SbRichTextImageOptimizationOptions,
-} from "@storyblok/richtext"
 
 let richTextResolver;
 
@@ -181,3 +162,23 @@ export {
 
 // Reexport all types so users can have access to them
 export * from "./types";
+
+/**
+ * This is a temporaly class to avoid type collision with the legacy richtext resolver.
+ * It will become ~~`newSbRichTextOptions`~~ -> `SbRichTextOptions` on v4.x
+ */
+export type newSbRichTextOptions = stdSbRichTextOptions;
+
+// New Richtext Resolver
+export {
+  BlockTypes,
+  MarkTypes,
+  richTextResolver,
+  TextTypes,
+  type SbRichTextDocumentNode,
+  type SbRichTextNodeTypes,
+  type SbRichTextNode,
+  type SbRichTextResolvers,
+  type SbRichTextNodeResolver,
+  type SbRichTextImageOptimizationOptions,
+} from "@storyblok/richtext"

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,6 +12,28 @@ import {
 
 import { RichtextResolver } from "storyblok-js-client";
 
+import { type SbRichTextOptions as stdSbRichTextOptions} from "@storyblok/richtext";
+
+/**
+ * This is a temporaly class to avoid type collision with the legacy richtext resolver.
+ * It will become ~~`newSbRichTextOptions`~~ -> `SbRichTextOptions` on v4.x
+ */
+export type newSbRichTextOptions = stdSbRichTextOptions;
+
+// New Richtext Resolver
+export {
+  BlockTypes,
+  MarkTypes,
+  richTextResolver,
+  TextTypes,
+  type SbRichTextDocumentNode,
+  type SbRichTextNodeTypes,
+  type SbRichTextNode,
+  type SbRichTextResolvers,
+  type SbRichTextNodeResolver,
+  type SbRichTextImageOptimizationOptions,
+} from "@storyblok/richtext"
+
 let richTextResolver;
 
 let bridgeLatest = "https://app.storyblok.com/f/storyblok-v2-latest.js";
@@ -90,6 +112,7 @@ export const storyblokInit = (pluginOptions: SbSDKOptions = {}) => {
   }
 
   // Rich Text resolver
+  // TODO: replace with @storyblok/richtext package on v4.x
   richTextResolver = new RichtextResolver(richText.schema);
   if (richText.resolver) {
     setComponentResolver(richTextResolver, richText.resolver);
@@ -134,12 +157,13 @@ export const renderRichText = (
   }
 
   if (options) {
+    // TODO: replace with @storyblok/richtext package on v4.x
     localResolver = new RichtextResolver(options.schema);
     if (options.resolver) {
       setComponentResolver(localResolver, options.resolver);
     }
   }
-
+  // NOTE: This will warn the user about deprecation of legacy Richtext when https://github.com/storyblok/storyblok-js-client/pull/845 is merged
   return localResolver.render(data);
 };
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@storyblok/richtext": "^1.0.0",
-    "storyblok-js-client": "^6.7.2"
+    "storyblok-js-client": "^6.9.0-next.1"
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.6",

--- a/lib/package.json
+++ b/lib/package.json
@@ -28,6 +28,7 @@
     "prepublishOnly": "npm run build && cp ../README.md ./"
   },
   "dependencies": {
+    "@storyblok/richtext": "^1.0.0",
     "storyblok-js-client": "^6.7.2"
   },
   "devDependencies": {

--- a/lib/tests/index.test.js
+++ b/lib/tests/index.test.js
@@ -83,7 +83,9 @@ describe("@storyblok/js", () => {
     })
   })
 
-  describe("Rich Text Resolver", () => {
+  // TODO: This might change when legacy rich text resolver is removed and 
+  // the new rich text resolver is implemented instead
+  describe("Legacy Rich Text Resolver", () => {
     it("should return the rendered HTML when passing a valid RichText object", () => {
       storyblokInit({ accessToken: "wANpEQEsMYGOwLxwXQ76Ggtt", bridge: false });
       expect(renderRichText(richTextFixture)).toMatchSnapshot();

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       "version": "2.0.6",
       "dependencies": {
         "@storyblok/richtext": "^1.0.0",
-        "storyblok-js-client": "^6.7.2"
+        "storyblok-js-client": "^6.9.0-next.1"
       },
       "devDependencies": {
         "@tsconfig/recommended": "^1.0.6",
@@ -6108,9 +6108,9 @@
       "dev": true
     },
     "node_modules/storyblok-js-client": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-6.7.2.tgz",
-      "integrity": "sha512-5+cCZQhvIPSP5fin7jMUyyiAfV3FSbhH2q0YmDpb8NqxsY0pog6r+igHshVXNHed5yB5AZcVn0Mduao0X1MdBA=="
+      "version": "6.9.0-next.1",
+      "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-6.9.0-next.1.tgz",
+      "integrity": "sha512-70O9TtuRN0O3V4ZmJrQ5qKCT4nGTIQLEEWvJRLfhv84AbMiLGyKJy9rglvhS0Ijjx4WdlYAqTG/b2ujuABhBlg=="
     },
     "node_modules/stream-combiner": {
       "version": "0.0.4",
@@ -8024,7 +8024,7 @@
         "eslint-plugin-jest": "^28.2.0",
         "isomorphic-fetch": "^3.0.0",
         "start-server-and-test": "^2.0.3",
-        "storyblok-js-client": "^6.7.2",
+        "storyblok-js-client": "^6.9.0-next.1",
         "vite": "^5.2.8",
         "vitest": "^1.5.0"
       }
@@ -10968,9 +10968,9 @@
       "dev": true
     },
     "storyblok-js-client": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-6.7.2.tgz",
-      "integrity": "sha512-5+cCZQhvIPSP5fin7jMUyyiAfV3FSbhH2q0YmDpb8NqxsY0pog6r+igHshVXNHed5yB5AZcVn0Mduao0X1MdBA=="
+      "version": "6.9.0-next.1",
+      "resolved": "https://registry.npmjs.org/storyblok-js-client/-/storyblok-js-client-6.9.0-next.1.tgz",
+      "integrity": "sha512-70O9TtuRN0O3V4ZmJrQ5qKCT4nGTIQLEEWvJRLfhv84AbMiLGyKJy9rglvhS0Ijjx4WdlYAqTG/b2ujuABhBlg=="
     },
     "stream-combiner": {
       "version": "0.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       "name": "@storyblok/js",
       "version": "2.0.6",
       "dependencies": {
+        "@storyblok/richtext": "^1.0.0",
         "storyblok-js-client": "^6.7.2"
       },
       "devDependencies": {
@@ -1775,6 +1776,14 @@
       "resolved": "playground",
       "link": true
     },
+    "node_modules/@storyblok/richtext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@storyblok/richtext/-/richtext-1.0.0.tgz",
+      "integrity": "sha512-zzdgyJuoOTw9jldtj1/0+S1952NnherH7M5iXQRq7ehg7RDz01RGZEBSwcwrDmkXjfa6i7yaZrBdqD3BLUb34A==",
+      "dependencies": {
+        "consola": "^3.2.3"
+      }
+    },
     "node_modules/@storyblok/vue-playground": {
       "resolved": "playground-vue",
       "link": true
@@ -2750,6 +2759,14 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
+      "integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
     },
     "node_modules/conventional-changelog-angular": {
       "version": "7.0.0",
@@ -8000,6 +8017,7 @@
     "@storyblok/js": {
       "version": "file:lib",
       "requires": {
+        "@storyblok/richtext": "^1.0.0",
         "@tsconfig/recommended": "^1.0.6",
         "cypress": "^13.7.3",
         "eslint-plugin-cypress": "^2.15.1",
@@ -8017,6 +8035,14 @@
         "@storyblok/js": "^2.0.6",
         "@vitejs/plugin-basic-ssl": "^1.1.0",
         "vite": "^5.2.8"
+      }
+    },
+    "@storyblok/richtext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@storyblok/richtext/-/richtext-1.0.0.tgz",
+      "integrity": "sha512-zzdgyJuoOTw9jldtj1/0+S1952NnherH7M5iXQRq7ehg7RDz01RGZEBSwcwrDmkXjfa6i7yaZrBdqD3BLUb34A==",
+      "requires": {
+        "consola": "^3.2.3"
       }
     },
     "@storyblok/vue-playground": {
@@ -8723,6 +8749,11 @@
     "concat-map": {
       "version": "0.0.1",
       "dev": true
+    },
+    "consola": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
+      "integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ=="
     },
     "conventional-changelog-angular": {
       "version": "7.0.0",

--- a/playground/index.html
+++ b/playground/index.html
@@ -31,6 +31,9 @@
     >
       renderRichTextWithOptions
     </button>
+    <button class="render-rich-text" onclick="newRichTextResolver()">
+      newRichTextRenderer
+    </button>
     <h3>Rich Text Renderer</h3>
     <div id="rich-text-container"></div>
     <script type="module" src="/main.ts"></script>

--- a/playground/main.ts
+++ b/playground/main.ts
@@ -4,6 +4,8 @@ import {
   renderRichText,
   useStoryblokBridge,
   apiPlugin,
+  richTextResolver,
+  newSbRichTextOptions
 } from "@storyblok/js";
 import richTextFixture from "../lib/fixtures/richTextObject.json";
 
@@ -43,6 +45,7 @@ declare global {
     initCustomRichText: any;
     renderRichText: any;
     renderRichTextWithOptions: any;
+    newRichTextResolver: any
   }
 }
 
@@ -104,3 +107,28 @@ window.renderRichTextWithOptions = () => {
 window.loadStoryblokBridgeScript = () => {
   loadStoryblokBridge();
 };
+
+window.newRichTextResolver = () => {
+  const options: newSbRichTextOptions = {
+    resolvers: {
+      custom_link: (node) => {
+        const attrs = { ...node.attrs };
+
+        return {
+          tag: [
+            {
+              tag: "a",
+              attrs: attrs,
+            },
+          ],
+        };
+      },
+    }
+  }
+  const html = richTextResolver(options).render(richTextFixture as any);
+  const richTextContainer = document.getElementById(
+    "rich-text-container"
+  ) as any;
+
+  richTextContainer.innerHTML = html;
+}


### PR DESCRIPTION
This PR introduces retro-compatibility support between:

- Legacy `RichTextResolver` from `storyblok-js-client`
- New `richtTextResolver` from `@storyblok/richtext`

Note:

There was a type collision between the two packages on `SbRichtTextOptions`. To avoid a breaking change, I opted to temporarily name the type coming from `@storyblok/richtext` as `newSbRichTextOptions` with a JSDoc note for the future change back.

```
import { type SbRichTextOptions as stdSbRichTextOptions} from "@storyblok/richtext";

/**
 * This is a temporaly class to avoid type collision with the legacy richtext resolver.
 * It will become ~~`newSbRichTextOptions`~~ -> `SbRichTextOptions` on v4.x
 */
export type newSbRichTextOptions = stdSbRichTextOptions;
```

![Screenshot 2024-07-31 at 10 45 01](https://github.com/user-attachments/assets/a262fef4-ade6-447f-8781-902ed9026107)


