### PR TITLE
feat(deps): update @storyblok/richtext to version 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "cy:open": "cypress open"
   },
   "dependencies": {
-    "@storyblok/richtext": "3.0.2",
+    "@storyblok/richtext": "3.1.0",
     "storyblok-js-client": "6.10.10"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@storyblok/richtext':
-        specifier: 3.0.2
-        version: 3.0.2
+        specifier: 3.1.0
+        version: 3.1.0
       storyblok-js-client:
         specifier: 6.10.10
         version: 6.10.10
@@ -734,8 +734,8 @@ packages:
     peerDependencies:
       eslint: '>=8.40.0'
 
-  '@storyblok/richtext@3.0.2':
-    resolution: {integrity: sha512-KBLx9ycNVMyVnNyPiwBH5g9uWmiJpMzp9YvpnnADXlPLoksusrwI56BusSM8HaIgJgcnB5RR0LvhySkPFdC8Zg==}
+  '@storyblok/richtext@3.1.0':
+    resolution: {integrity: sha512-QtH5G+F7w3YuGGnHAFldo71vPpBT5prndZWFPDihlIsWaW0rEWyE9iX+6fp2f4XDgbhi0vyF1HqajFplGOtFVg==}
 
   '@stylistic/eslint-plugin@2.11.0':
     resolution: {integrity: sha512-PNRHbydNG5EH8NK4c+izdJlxajIR6GxcUhzsYNRsn6Myep4dsZt0qFCz3rCPnkvgO5FYibDcMqgNHUT+zvjYZw==}
@@ -3941,7 +3941,7 @@ snapshots:
       - typescript
       - vitest
 
-  '@storyblok/richtext@3.0.2': {}
+  '@storyblok/richtext@3.1.0': {}
 
   '@stylistic/eslint-plugin@2.11.0(eslint@9.19.0(jiti@2.4.2))(typescript@5.8.2)':
     dependencies:


### PR DESCRIPTION
Bumps the @storyblok/richtext dependency from 3.0.2 to 3.1.0. This update contains richtext table resolver support